### PR TITLE
feat: add environment-based protocol switching for rewrites

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
+const JP_DOMAIN = process.env.JP_DOMAIN || '';
+const PROTOCOL = process.env.NODE_ENV === 'development' ? 'http' : 'https';
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: '/jp',
+        destination: `${PROTOCOL}://${JP_DOMAIN}/jp`,
+      },
+      {
+        source: '/jp/:path*',
+        destination: `${PROTOCOL}://${JP_DOMAIN}/jp/:path*`,
+      },
+    ]
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Add PROTOCOL variable that uses http for development, https for production
- Configure Next.js rewrites to use dynamic protocol with JP_DOMAIN
- Enable proper routing for /jp paths across different environments

🤖 Generated with [Claude Code](https://claude.ai/code)