### PR TITLE
feat: add placehold.jp to remotePatterns for rewrite destination images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,12 @@ const nextConfig: NextConfig = {
         hostname: JP_DOMAIN,
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'placehold.jp',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
- Add placehold.jp hostname to Next.js image remotePatterns
- Enable loading of placeholder images used in rewrite destination pages
- Support external image service for development and testing

🤖 Generated with [Claude Code](https://claude.ai/code)